### PR TITLE
feat: fork patches for dart_monty (CancellableTracker, async fix, CI)

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,145 @@
+name: Fork CI
+
+on:
+  push:
+    branches: [runyaga/main, 'feat/**']
+  pull_request:
+    branches: [runyaga/main]
+
+env:
+  COLUMNS: 150
+  UV_PYTHON: "3.14"
+  UV_FROZEN: "1"
+  DEBUG: "napi:*"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          prefix-key: "v1-rust"
+
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync --all-packages --only-dev
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.UV_PYTHON }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/monty-js/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: crates/monty-js
+
+      - run: uvx pre-commit run --color=always --all-files --verbose
+        env:
+          SKIP: no-commit-to-branch
+
+      - name: Show diff on failure
+        if: failure()
+        run: git diff
+
+  test-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - run: rustc --version --verbose
+      - run: python3 -V
+      - run: rm .cargo/config.toml
+
+      # coverage for make test-no-features
+      - run: cargo llvm-cov --no-report -p monty
+      # coverage for make test-ref-count-panic
+      - run: cargo llvm-cov --no-report -p monty --features ref-count-panic
+      # coverage for make test-ref-count-return
+      - run: cargo llvm-cov --no-report -p monty --features ref-count-return
+      # coverage for make test-type-checking
+      - run: cargo llvm-cov --no-report -p monty_type_checking -p monty_typeshed
+      # text report
+      - run: cargo llvm-cov report --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'
+
+  test-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: crates/monty-js/package-lock.json
+
+      - run: rm .cargo/config.toml
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: crates/monty-js
+
+      - name: Build (debug)
+        run: npm run build:debug
+        working-directory: crates/monty-js
+
+      - name: Test
+        run: npm test
+        working-directory: crates/monty-js
+
+  bench-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - run: rm .cargo/config.toml
+      - run: make dev-bench
+
+  check:
+    if: always()
+    needs: [lint, test-rust, test-js, bench-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,69 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Monday 6am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/pydantic/monty.git
+
+      - name: Fetch upstream
+        run: git fetch upstream main
+
+      - name: Fast-forward main
+        run: |
+          git checkout main
+          git merge --ff-only upstream/main
+          git push origin main
+
+      - name: Rebase integration branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout runyaga/main || git checkout -b runyaga/main
+          if ! git rebase main; then
+            git rebase --abort
+            gh issue create \
+              --title "Upstream sync: rebase conflict on runyaga/main" \
+              --body "Automated rebase of runyaga/main onto updated main failed. Manual resolution needed." \
+              --label "sync"
+            exit 1
+          fi
+          git push origin runyaga/main --force-with-lease
+
+      - name: Check feature branch staleness
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for branch in $(git branch -r --list 'origin/feat/*'); do
+            branch_name=${branch#origin/}
+            base=$(git merge-base main "$branch")
+            behind=$(git rev-list --count "$base"..main)
+            if [ "$behind" -gt 25 ]; then
+              echo "::warning::Branch $branch_name is $behind commits behind main"
+              gh issue create \
+                --title "Stale branch: $branch_name ($behind commits behind)" \
+                --body "Branch \`$branch_name\` is $behind commits behind main. Rebase recommended to avoid the FutureSnapshot-v1 problem." \
+                --label "sync,stale-branch" \
+                2>/dev/null || true
+            fi
+          done

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -763,18 +763,14 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         if let Some((gather_id, result_idx)) = self.scheduler_mut().take_gather_waiter(call_id) {
             // Remove from scheduler's pending_calls so it doesn't appear in get_pending_call_ids()
             self.scheduler_mut().remove_pending_call(call_id);
-            // Store result directly in gather (move, not clone) and check completion
+            // Store result in gather and check completion
             let (pending_empty, task_ids, waiter) =
                 if let HeapDataMut::GatherFuture(gather) = self.heap.get_mut(gather_id) {
-                    gather.results[result_idx] = Some(value); // Move value directly, no clone needed
-                    // Remove from pending_calls
+                    gather.results[result_idx] = Some(value);
                     gather.pending_calls.retain(|&cid| cid != call_id);
-                    // Take task_ids to avoid clone - we're checking completion so gather may be destroyed
-                    (
-                        gather.pending_calls.is_empty(),
-                        std::mem::take(&mut gather.task_ids),
-                        gather.waiter,
-                    )
+                    // Clone task_ids — mem::take would leave an empty vec that makes
+                    // handle_task_completion falsely consider the gather vacuously complete.
+                    (gather.pending_calls.is_empty(), gather.task_ids.clone(), gather.waiter)
                 } else {
                     (true, vec![], None)
                 };
@@ -946,6 +942,12 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     /// # Returns
     /// `true` if a value was pushed, `false` if no task was ready to continue.
     pub fn prepare_current_task_after_resolve(&mut self) -> bool {
+        // If frames were drained during a previous partial resume, fall back to
+        // load_ready_task_if_needed to restore the task context first.
+        if self.frames.is_empty() {
+            return false;
+        }
+
         let Some(scheduler) = &mut self.scheduler else {
             return false;
         };

--- a/crates/monty/src/cancellable_tracker.rs
+++ b/crates/monty/src/cancellable_tracker.rs
@@ -1,0 +1,301 @@
+//! A resource tracker wrapper that adds preemptive cancellation support.
+//!
+//! `CancellableTracker` wraps any `ResourceTracker` implementation and adds an
+//! `Arc<AtomicBool>` cancel flag. External code (e.g., another thread, Dart FFI,
+//! a signal handler) can set the flag to `true` to request cancellation. On the
+//! next `check_time` or `on_allocate` call the tracker will return a
+//! `ResourceError`, terminating the running script.
+//!
+//! The cancel flag is checked with `Ordering::Relaxed` because we only need
+//! eventual visibility — a few extra bytecodes executing before the flag is
+//! observed is acceptable, and relaxed loads are essentially free on all
+//! architectures Monty targets (x86-64, aarch64, wasm32).
+
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use crate::{
+    ExcType, MontyException,
+    resource::{ResourceError, ResourceTracker},
+};
+
+/// A resource tracker that wraps an inner tracker with a cooperative cancel flag.
+///
+/// On each `check_time` and `on_allocate` call the atomic flag is inspected
+/// first. If set, a `ResourceError::Exception` carrying a `KeyboardInterrupt`
+/// is returned immediately — the same exception CPython raises on Ctrl+C.
+/// Because resource errors (other than `RecursionError`) are converted to
+/// uncatchable exceptions by the VM, Python code cannot suppress the
+/// cancellation with a bare `except:`.
+///
+/// # Thread safety
+///
+/// The cancel flag is an `Arc<AtomicBool>` — clone it via [`cancel_flag`] and
+/// hand the clone to whatever external context needs the ability to cancel
+/// (another OS thread, a Dart isolate via FFI, a signal handler, etc.).
+///
+/// [`cancel_flag`]: CancellableTracker::cancel_flag
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use std::sync::atomic::AtomicBool;
+/// use monty::{CancellableTracker, NoLimitTracker};
+///
+/// let tracker = CancellableTracker::new(NoLimitTracker);
+/// let flag = tracker.cancel_flag();
+///
+/// // Hand `flag` to another thread, then later:
+/// flag.store(true, std::sync::atomic::Ordering::Relaxed);
+/// ```
+pub struct CancellableTracker<T> {
+    /// The wrapped resource tracker that handles allocation/time/memory limits.
+    inner: T,
+    /// Shared cancel flag. `true` means cancellation has been requested.
+    cancelled: Arc<AtomicBool>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for CancellableTracker<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CancellableTracker")
+            .field("inner", &self.inner)
+            .field("cancelled", &self.cancelled.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl<T> CancellableTracker<T> {
+    /// Creates a new `CancellableTracker` wrapping the given inner tracker.
+    ///
+    /// The cancel flag starts as `false` (not cancelled).
+    #[must_use]
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Creates a new `CancellableTracker` with an externally provided cancel flag.
+    ///
+    /// This is useful when the flag must be created before the tracker — for
+    /// example, when a Dart FFI handle needs to store the flag pointer before
+    /// execution begins.
+    #[must_use]
+    pub fn with_flag(inner: T, cancelled: Arc<AtomicBool>) -> Self {
+        Self { inner, cancelled }
+    }
+
+    /// Returns a clone of the cancel flag.
+    ///
+    /// The returned `Arc<AtomicBool>` can be sent to another thread or stored
+    /// in an FFI handle. Setting it to `true` (with any ordering) will cause
+    /// the next resource check to abort execution.
+    #[must_use]
+    pub fn cancel_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancelled)
+    }
+
+    /// Returns `true` if cancellation has been requested.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Relaxed)
+    }
+
+    /// Requests cancellation of the running script.
+    ///
+    /// Equivalent to `cancel_flag().store(true, Relaxed)` but slightly more
+    /// convenient when you have direct access to the tracker.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+
+    /// Resets the cancel flag to `false`.
+    ///
+    /// Call this before re-using the tracker for a new execution run.
+    pub fn reset(&self) {
+        self.cancelled.store(false, Ordering::Relaxed);
+    }
+
+    /// Returns a shared reference to the inner tracker.
+    #[must_use]
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner tracker.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Checks the cancel flag and returns an error if set.
+    #[inline]
+    fn check_cancelled(&self) -> Result<(), ResourceError> {
+        if self.cancelled.load(Ordering::Relaxed) {
+            Err(ResourceError::Exception(MontyException::new_full(
+                ExcType::KeyboardInterrupt,
+                Some("Script execution cancelled".to_string()),
+                vec![],
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<T: ResourceTracker> ResourceTracker for CancellableTracker<T> {
+    #[inline]
+    fn on_allocate(&mut self, get_size: impl FnOnce() -> usize) -> Result<(), ResourceError> {
+        self.check_cancelled()?;
+        self.inner.on_allocate(get_size)
+    }
+
+    #[inline]
+    fn on_free(&mut self, get_size: impl FnOnce() -> usize) {
+        self.inner.on_free(get_size);
+    }
+
+    #[inline]
+    fn check_time(&self) -> Result<(), ResourceError> {
+        self.check_cancelled()?;
+        self.inner.check_time()
+    }
+
+    #[inline]
+    fn check_recursion_depth(&self, current_depth: usize) -> Result<(), ResourceError> {
+        self.inner.check_recursion_depth(current_depth)
+    }
+
+    #[inline]
+    fn check_large_result(&self, estimated_bytes: usize) -> Result<(), ResourceError> {
+        self.inner.check_large_result(estimated_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+    use crate::resource::{LimitedTracker, NoLimitTracker, ResourceLimits};
+
+    #[test]
+    fn uncancelled_delegates_to_inner() {
+        let mut tracker = CancellableTracker::new(NoLimitTracker);
+        assert!(tracker.on_allocate(|| 100).is_ok());
+        assert!(tracker.check_time().is_ok());
+        assert!(tracker.check_recursion_depth(5).is_ok());
+        assert!(tracker.check_large_result(1_000_000).is_ok());
+    }
+
+    #[test]
+    fn cancel_flag_stops_check_time() {
+        let tracker = CancellableTracker::new(NoLimitTracker);
+        let flag = tracker.cancel_flag();
+
+        assert!(tracker.check_time().is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+
+        let err = tracker.check_time().unwrap_err();
+        assert!(matches!(err, ResourceError::Exception(ref e) if e.exc_type() == ExcType::KeyboardInterrupt));
+    }
+
+    #[test]
+    fn cancel_flag_stops_on_allocate() {
+        let mut tracker = CancellableTracker::new(NoLimitTracker);
+        let flag = tracker.cancel_flag();
+
+        flag.store(true, Ordering::Relaxed);
+
+        let err = tracker.on_allocate(|| 64).unwrap_err();
+        assert!(matches!(err, ResourceError::Exception(ref e) if e.exc_type() == ExcType::KeyboardInterrupt));
+    }
+
+    #[test]
+    fn reset_clears_cancel() {
+        let mut tracker = CancellableTracker::new(NoLimitTracker);
+
+        tracker.cancel();
+        assert!(tracker.is_cancelled());
+        assert!(tracker.check_time().is_err());
+
+        tracker.reset();
+        assert!(!tracker.is_cancelled());
+        assert!(tracker.check_time().is_ok());
+        assert!(tracker.on_allocate(|| 64).is_ok());
+    }
+
+    #[test]
+    fn with_flag_uses_external_flag() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let tracker = CancellableTracker::with_flag(NoLimitTracker, Arc::clone(&flag));
+
+        assert!(tracker.check_time().is_ok());
+
+        flag.store(true, Ordering::Relaxed);
+        assert!(tracker.check_time().is_err());
+    }
+
+    #[test]
+    fn inner_limits_still_enforced() {
+        let limits = ResourceLimits::new().max_allocations(2);
+        let mut tracker = CancellableTracker::new(LimitedTracker::new(limits));
+
+        assert!(tracker.on_allocate(|| 10).is_ok());
+        assert!(tracker.on_allocate(|| 10).is_ok());
+
+        // Third allocation should hit the inner tracker's limit, not the cancel flag
+        let err = tracker.on_allocate(|| 10).unwrap_err();
+        assert!(matches!(err, ResourceError::Allocation { limit: 2, .. }));
+    }
+
+    #[test]
+    fn cancel_takes_priority_over_inner_limits() {
+        let limits = ResourceLimits::new().max_allocations(100);
+        let mut tracker = CancellableTracker::new(LimitedTracker::new(limits));
+
+        tracker.cancel();
+
+        // Cancel flag is checked first, so we get a cancellation error
+        // even though the allocation limit hasn't been reached
+        let err = tracker.on_allocate(|| 10).unwrap_err();
+        assert!(matches!(err, ResourceError::Exception(ref e) if e.exc_type() == ExcType::KeyboardInterrupt));
+    }
+
+    #[test]
+    fn on_free_delegates() {
+        let limits = ResourceLimits::new().max_memory(1000);
+        let mut tracker = CancellableTracker::new(LimitedTracker::new(limits));
+
+        tracker.on_allocate(|| 500).unwrap();
+        assert_eq!(tracker.inner().current_memory(), 500);
+
+        tracker.on_free(|| 200);
+        assert_eq!(tracker.inner().current_memory(), 300);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let tracker = CancellableTracker::new(NoLimitTracker);
+        let debug_str = format!("{tracker:?}");
+        assert!(debug_str.contains("CancellableTracker"));
+        assert!(debug_str.contains("cancelled: false"));
+    }
+
+    #[test]
+    fn error_message_content() {
+        let tracker = CancellableTracker::new(NoLimitTracker);
+        tracker.cancel();
+
+        let err = tracker.check_time().unwrap_err();
+        let msg = format!("{err}");
+        assert_eq!(msg, "KeyboardInterrupt: Script execution cancelled");
+    }
+}

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -6,6 +6,7 @@ mod args;
 mod asyncio;
 mod builtins;
 mod bytecode;
+mod cancellable_tracker;
 mod exception_private;
 mod exception_public;
 mod expressions;
@@ -33,6 +34,7 @@ mod value;
 #[cfg(feature = "ref-count-return")]
 pub use crate::run::RefCountOutput;
 pub use crate::{
+    cancellable_tracker::CancellableTracker,
     exception_private::ExcType,
     exception_public::{CodeLoc, MontyException, StackFrame},
     io::{PrintWriter, PrintWriterCallback},

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -539,6 +539,62 @@ fn incremental_resolution_error_on_second_round() {
     assert_eq!(exc.message(), Some("delayed failure"));
 }
 
+// === Test: Partial resolution with mixed coroutine task + direct external call ===
+// This reproduces a panic ("no active frame") when a gather mixes a coroutine
+// task (which itself awaits an external call) with a direct external call,
+// and only the task's external call is resolved first.
+
+#[test]
+fn gather_mixed_coroutine_and_direct_external_partial_resolve() {
+    let code = r"
+import asyncio
+
+async def double(x):
+    val = await async_call(x)
+    return val * 2
+
+results = await asyncio.gather(double(5), async_call(100))
+results
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let progress = runner.start(vec![], NoLimitTracker, &mut PrintWriter::Stdout).unwrap();
+
+    // Use drive_collecting_calls so we know which call_id maps to which invocation.
+    // Call order: async_call(100) (gather direct) then async_call(5) (double's inner).
+    let (state, calls) = drive_collecting_calls(progress);
+    assert_eq!(calls.len(), 2, "should have 2 external calls");
+    assert_eq!(state.pending_call_ids().len(), 2, "should have 2 pending calls");
+
+    // Resolve the gather's direct external call first: async_call(100) → returns 100.
+    // This is a partial resolution — double(5) is still blocked on its own async_call(5).
+    let results = vec![(calls[0].0, ExtFunctionResult::Return(MontyObject::Int(100)))];
+    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+
+    // Should return ResolveFutures with the remaining call (async_call(5) for double)
+    let state = progress
+        .into_resolve_futures()
+        .expect("should need more futures (double's async_call(5) still pending)");
+
+    assert_eq!(
+        state.pending_call_ids().len(),
+        1,
+        "should have 1 remaining pending call"
+    );
+
+    // Resolve double's inner call: async_call(5) → returns 5.
+    // double(5) will then compute 5 * 2 = 10.
+    let results = vec![(calls[1].0, ExtFunctionResult::Return(MontyObject::Int(5)))];
+    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+
+    // gather(double(5), async_call(100)) = [10, 100]
+    let result = progress.into_complete().expect("should complete");
+    assert_eq!(
+        result,
+        MontyObject::List(vec![MontyObject::Int(10), MontyObject::Int(100)])
+    );
+}
+
 // === Test: Gather with all at once, mixed success/failure ===
 
 #[test]
@@ -608,6 +664,85 @@ fn drive_collecting_calls<T: monty::ResourceTracker>(
             }
         }
     }
+}
+
+// === Test: mem::take corruption in resolve_future gather path (3-item gather) ===
+// This test targets the data corruption caused by `std::mem::take(&mut gather.task_ids)`
+// in resolve_future(). With 3 items (2 coroutines + 1 direct external), resolving the
+// direct external first empties gather.task_ids. When a coroutine completes later,
+// handle_task_completion reads the empty task_ids and falsely considers the gather
+// complete, panicking on None for the unfinished coroutine's result.
+//
+// Resolution order that triggers the bug:
+// 1. Resolve C_direct → gather.task_ids corrupted (emptied by mem::take)
+// 2. Resolve slow_a's inner call → slow_a runs to completion
+// 3. handle_task_completion: gather.task_ids = [] → all_tasks_complete = vacuously true
+// 4. Panics on .expect("all results should be filled") because slow_b's result is None
+
+#[test]
+fn gather_three_tasks_with_direct_external_memtake_corruption() {
+    let code = r"
+import asyncio
+
+async def slow_a():
+    val = await async_call(1)
+    return val
+
+async def slow_b():
+    val = await async_call(2)
+    return val
+
+results = await asyncio.gather(slow_a(), slow_b(), async_call(999))
+results
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let progress = runner.start(vec![], NoLimitTracker, &mut PrintWriter::Stdout).unwrap();
+
+    let (state, call_ids) = drive_to_resolve_futures(progress);
+    // 3 calls: async_call(999) from gather, async_call(1) from slow_a, async_call(2) from slow_b
+    assert_eq!(call_ids.len(), 3, "should have 3 external calls");
+    assert_eq!(state.pending_call_ids().len(), 3, "should have 3 pending calls");
+
+    // Resolve only the gather's direct external call first (call_ids[0] = async_call(999)).
+    // This triggers mem::take on gather.task_ids, corrupting it to [].
+    let results = vec![(call_ids[0], ExtFunctionResult::Return(MontyObject::Int(999)))];
+    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+
+    let state = progress
+        .into_resolve_futures()
+        .expect("should need more futures (slow_a and slow_b still pending)");
+
+    // Now resolve one coroutine's inner call. This will make that coroutine complete.
+    // With the mem::take bug, handle_task_completion would see gather.task_ids = []
+    // (corrupted) and falsely consider the gather complete, panicking on the other
+    // coroutine's None result.
+    let remaining = state.pending_call_ids();
+    assert_eq!(remaining.len(), 2, "should have 2 remaining calls");
+
+    // Resolve one of the remaining calls (both coroutines return the same value
+    // since call ordering between slow_a/slow_b is nondeterministic)
+    let results = vec![(remaining[0], ExtFunctionResult::Return(MontyObject::Int(42)))];
+    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+
+    // After the first coroutine completes, we should still need the second coroutine's result
+    let state = progress
+        .into_resolve_futures()
+        .expect("should need more futures (one coroutine still pending)");
+
+    assert_eq!(state.pending_call_ids().len(), 1, "should have 1 remaining call");
+
+    // Resolve the last call (same value — both coroutines just return `val`)
+    let last_id = state.pending_call_ids()[0];
+    let results = vec![(last_id, ExtFunctionResult::Return(MontyObject::Int(42)))];
+    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+
+    // Should complete with all three results: [slow_a=42, slow_b=42, direct=999]
+    let result = progress.into_complete().expect("should complete");
+    assert_eq!(
+        result,
+        MontyObject::List(vec![MontyObject::Int(42), MontyObject::Int(42), MontyObject::Int(999),])
+    );
 }
 
 /// Tests nested gathers where spawned tasks do sequential external await then inner gather.

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -558,7 +558,7 @@ results
 ";
     let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
 
-    let progress = runner.start(vec![], NoLimitTracker, &mut PrintWriter::Stdout).unwrap();
+    let progress = runner.start(vec![], NoLimitTracker, PrintWriter::Stdout).unwrap();
 
     // Use drive_collecting_calls so we know which call_id maps to which invocation.
     // Call order: async_call(100) (gather direct) then async_call(5) (double's inner).
@@ -569,7 +569,7 @@ results
     // Resolve the gather's direct external call first: async_call(100) → returns 100.
     // This is a partial resolution — double(5) is still blocked on its own async_call(5).
     let results = vec![(calls[0].0, ExtFunctionResult::Return(MontyObject::Int(100)))];
-    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+    let progress = state.resume(results, PrintWriter::Stdout).unwrap();
 
     // Should return ResolveFutures with the remaining call (async_call(5) for double)
     let state = progress
@@ -585,7 +585,7 @@ results
     // Resolve double's inner call: async_call(5) → returns 5.
     // double(5) will then compute 5 * 2 = 10.
     let results = vec![(calls[1].0, ExtFunctionResult::Return(MontyObject::Int(5)))];
-    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+    let progress = state.resume(results, PrintWriter::Stdout).unwrap();
 
     // gather(double(5), async_call(100)) = [10, 100]
     let result = progress.into_complete().expect("should complete");
@@ -697,7 +697,7 @@ results
 ";
     let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
 
-    let progress = runner.start(vec![], NoLimitTracker, &mut PrintWriter::Stdout).unwrap();
+    let progress = runner.start(vec![], NoLimitTracker, PrintWriter::Stdout).unwrap();
 
     let (state, call_ids) = drive_to_resolve_futures(progress);
     // 3 calls: async_call(999) from gather, async_call(1) from slow_a, async_call(2) from slow_b
@@ -707,7 +707,7 @@ results
     // Resolve only the gather's direct external call first (call_ids[0] = async_call(999)).
     // This triggers mem::take on gather.task_ids, corrupting it to [].
     let results = vec![(call_ids[0], ExtFunctionResult::Return(MontyObject::Int(999)))];
-    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+    let progress = state.resume(results, PrintWriter::Stdout).unwrap();
 
     let state = progress
         .into_resolve_futures()
@@ -723,7 +723,7 @@ results
     // Resolve one of the remaining calls (both coroutines return the same value
     // since call ordering between slow_a/slow_b is nondeterministic)
     let results = vec![(remaining[0], ExtFunctionResult::Return(MontyObject::Int(42)))];
-    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+    let progress = state.resume(results, PrintWriter::Stdout).unwrap();
 
     // After the first coroutine completes, we should still need the second coroutine's result
     let state = progress
@@ -735,7 +735,7 @@ results
     // Resolve the last call (same value — both coroutines just return `val`)
     let last_id = state.pending_call_ids()[0];
     let results = vec![(last_id, ExtFunctionResult::Return(MontyObject::Int(42)))];
-    let progress = state.resume(results, &mut PrintWriter::Stdout).unwrap();
+    let progress = state.resume(results, PrintWriter::Stdout).unwrap();
 
     // Should complete with all three results: [slow_a=42, slow_b=42, direct=999]
     let result = progress.into_complete().expect("should complete");

--- a/crates/monty/tests/foriter_start_resume.rs
+++ b/crates/monty/tests/foriter_start_resume.rs
@@ -1,0 +1,592 @@
+//! Reproducer for dart_monty#225: ForIter stack corruption in start/resume path.
+//!
+//! These tests verify that the `start()` → `NameLookup::resume()` →
+//! `FunctionCall::resume()` path correctly preserves iterator stack state
+//! across nested for-loops with try/except blocks.
+//!
+//! The bug: 13 of 32 variants crash with
+//! "ForIter: expected iterator ref on stack" when executed via start/resume,
+//! but pass when executed via run() (which handles everything internally).
+//!
+//! Trigger conditions (ALL three required):
+//! - 3+ for-loops in the same scope
+//! - try/except in 2+ of those loops
+//! - 3rd loop iterates 4+ items
+
+use monty::{
+    CancellableTracker, MontyObject, MontyRun, NameLookupResult, NoLimitTracker, PrintWriter,
+    RunProgress,
+};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+/// Drive execution to completion, resolving NameLookups as Undefined
+/// and FunctionCalls with simple returns.
+///
+/// This mimics what dart_monty's `process_progress` does: NameLookups
+/// for unknown names get `Undefined` (VM uses built-in lookup), and
+/// any external function call gets a simple return value.
+fn drive_to_completion(
+    mut progress: RunProgress<NoLimitTracker>,
+    ext_fn_names: &[&str],
+) -> Result<MontyObject, monty::MontyException> {
+    let mut print_output = Vec::new();
+
+    loop {
+        match progress {
+            RunProgress::Complete(obj) => return Ok(obj),
+            RunProgress::NameLookup(lookup) => {
+                let result = if ext_fn_names.contains(&lookup.name.as_str()) {
+                    NameLookupResult::Value(MontyObject::Function {
+                        name: lookup.name.clone(),
+                        docstring: None,
+                    })
+                } else {
+                    NameLookupResult::Undefined
+                };
+                progress = lookup.resume(result, PrintWriter::Stdout)?;
+            }
+            RunProgress::FunctionCall(call) => {
+                // For print-like functions, return None
+                if call.function_name == "capture" {
+                    // Capture the args for verification
+                    for arg in &call.args {
+                        print_output.push(format!("{:?}", arg));
+                    }
+                    progress = call.resume(MontyObject::None, PrintWriter::Stdout)?;
+                } else {
+                    progress = call.resume(MontyObject::None, PrintWriter::Stdout)?;
+                }
+            }
+            RunProgress::ResolveFutures(_) => {
+                panic!("unexpected ResolveFutures in synchronous test");
+            }
+            RunProgress::OsCall(_) => {
+                panic!("unexpected OsCall in synchronous test");
+            }
+        }
+    }
+}
+
+/// Helper: run code via start/resume path with no external functions.
+/// All NameLookups resolved as Undefined (VM handles builtins internally).
+fn run_via_start_resume(code: &str) -> Result<MontyObject, monty::MontyException> {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+    let progress = runner.start(vec![], NoLimitTracker, PrintWriter::Stdout)?;
+    drive_to_completion(progress, &[])
+}
+
+/// Helper: run code via start/resume path with named external functions.
+fn run_via_start_resume_with_ext(
+    code: &str,
+    ext_fns: &[&str],
+) -> Result<MontyObject, monty::MontyException> {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+    let progress = runner.start(vec![], NoLimitTracker, PrintWriter::Stdout)?;
+    drive_to_completion(progress, ext_fns)
+}
+
+/// Drive execution matching dart_monty's handle.rs pattern EXACTLY:
+/// - CancellableTracker wrapping NoLimitTracker
+/// - PrintWriter::Collect with short-lived buffer per NameLookup
+/// - Buffer created and destroyed on each NameLookup iteration
+fn drive_to_completion_dartmonty_style(
+    mut progress: RunProgress<CancellableTracker<NoLimitTracker>>,
+    ext_fn_names: &[&str],
+) -> Result<MontyObject, monty::MontyException> {
+    // Initial start() already consumed one PrintWriter::Collect.
+    // Now handle NameLookups with NEW short-lived buffers each time
+    // (matching handle.rs process_progress).
+    loop {
+        match progress {
+            RunProgress::Complete(obj) => return Ok(obj),
+            RunProgress::NameLookup(lookup) => {
+                // dart_monty creates a NEW buffer for EVERY NameLookup
+                let mut buf = String::new();
+                let result = if ext_fn_names.contains(&lookup.name.as_str()) {
+                    NameLookupResult::Value(MontyObject::Function {
+                        name: lookup.name.clone(),
+                        docstring: None,
+                    })
+                } else {
+                    NameLookupResult::Undefined
+                };
+                let next = lookup.resume(result, PrintWriter::Collect(&mut buf))?;
+                // buf dropped here (matching handle.rs)
+                progress = next;
+            }
+            RunProgress::FunctionCall(call) => {
+                let mut buf = String::new();
+                progress = call.resume(
+                    MontyObject::None,
+                    PrintWriter::Collect(&mut buf),
+                )?;
+            }
+            RunProgress::ResolveFutures(_) => {
+                panic!("unexpected ResolveFutures");
+            }
+            RunProgress::OsCall(_) => {
+                panic!("unexpected OsCall");
+            }
+        }
+    }
+}
+
+/// Helper: run via start/resume matching dart_monty's EXACT pattern.
+/// Uses CancellableTracker + PrintWriter::Collect with short-lived buffers.
+fn run_via_start_resume_dartmonty_style(
+    code: &str,
+) -> Result<MontyObject, monty::MontyException> {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    let tracker = CancellableTracker::with_flag(NoLimitTracker, cancel_flag);
+
+    // dart_monty's run_snapshot_op creates a short-lived buffer for start() too
+    let mut start_buf = String::new();
+    let progress = runner.start(vec![], tracker, PrintWriter::Collect(&mut start_buf))?;
+    // start_buf contents would be drained here in dart_monty
+    drive_to_completion_dartmonty_style(progress, &[])
+}
+
+/// Helper: run code via run() path (single internal loop, no start/resume).
+fn run_via_run(code: &str) -> Result<MontyObject, monty::MontyException> {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+    runner.run(vec![], NoLimitTracker, PrintWriter::Stdout)
+}
+
+// ---------------------------------------------------------------------------
+// Minimal crash code from dart_monty#225 debug plan
+// ---------------------------------------------------------------------------
+
+const MINIMAL_CRASH: &str = r#"
+data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}, {"a": 7, "b": 8}]
+first = data[0]
+
+found = None
+for k in first:
+    if k == "a":
+        found = k
+        break
+
+if found is None:
+    for k in first:
+        try:
+            _ = float(first.get(k, ""))
+            found = k
+            break
+        except Exception:
+            continue
+
+total = 0
+for row in data:
+    try:
+        total = total + row.get(found, 0)
+    except Exception:
+        continue
+
+total
+"#;
+
+/// The exact minimal crash code from the debug plan.
+/// This MUST pass via run() (baseline).
+#[test]
+fn minimal_crash_via_run() {
+    let result = run_via_run(MINIMAL_CRASH).unwrap();
+    assert_eq!(result, MontyObject::Int(16));
+}
+
+/// The exact minimal crash code via start/resume.
+/// This is the bug: if it crashes with "ForIter: expected iterator ref on stack",
+/// the bug is in monty's start/resume snapshot/restore path.
+#[test]
+fn minimal_crash_via_start_resume() {
+    let result = run_via_start_resume(MINIMAL_CRASH).unwrap();
+    assert_eq!(result, MontyObject::Int(16));
+}
+
+// ---------------------------------------------------------------------------
+// Variant K: 3 loops, try in 2nd and 3rd (simplest failing variant)
+// ---------------------------------------------------------------------------
+
+const VARIANT_K: &str = r#"
+rows = [
+    {"id": 1, "name": "Alice", "value": 250.0},
+    {"id": 2, "name": "Bob", "value": 175.5},
+    {"id": 3, "name": "Charlie", "value": ""},
+    {"id": 4, "name": "Dana", "value": 324.5},
+]
+first_row = rows[0]
+candidate = None
+for key in first_row:
+    if key == "value":
+        candidate = key
+        break
+if candidate is None:
+    for key in first_row:
+        try:
+            _ = float(first_row.get(key, ""))
+            candidate = key
+            break
+        except Exception:
+            continue
+total = 0.0
+if candidate:
+    for r in rows:
+        try:
+            total += float(r.get(candidate, ""))
+        except Exception:
+            continue
+total
+"#;
+
+#[test]
+fn variant_k_via_run() {
+    let result = run_via_run(VARIANT_K).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_k_via_start_resume() {
+    let result = run_via_start_resume(VARIANT_K).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+// ---------------------------------------------------------------------------
+// Variant D: 3 loops, NO try/except (should pass in both paths)
+// ---------------------------------------------------------------------------
+
+const VARIANT_D: &str = r#"
+rows = [
+    {"id": 1, "name": "Alice", "value": 250.0},
+    {"id": 2, "name": "Bob", "value": 175.5},
+    {"id": 3, "name": "Charlie", "value": ""},
+    {"id": 4, "name": "Dana", "value": 324.5},
+]
+first_row = rows[0]
+candidate = None
+for key in first_row:
+    if key == "value":
+        candidate = key
+        break
+if candidate is None:
+    for key in first_row:
+        candidate = key
+        break
+total = 0.0
+if candidate:
+    for r in rows:
+        total += 1
+total
+"#;
+
+#[test]
+fn variant_d_no_try_via_run() {
+    let result = run_via_run(VARIANT_D).unwrap();
+    assert_eq!(result, MontyObject::Float(4.0));
+}
+
+#[test]
+fn variant_d_no_try_via_start_resume() {
+    let result = run_via_start_resume(VARIANT_D).unwrap();
+    assert_eq!(result, MontyObject::Float(4.0));
+}
+
+// ---------------------------------------------------------------------------
+// Variant AC: 3 loops, try in 2nd+3rd, but only 3 rows (should pass)
+// ---------------------------------------------------------------------------
+
+const VARIANT_AC: &str = r#"
+rows = [
+    {"id": 1, "name": "Alice", "value": 250.0},
+    {"id": 2, "name": "Bob", "value": 175.5},
+    {"id": 3, "name": "Charlie", "value": 324.5},
+]
+first_row = rows[0]
+candidate = None
+for key in first_row:
+    if key == "value":
+        candidate = key
+        break
+if candidate is None:
+    for key in first_row:
+        try:
+            _ = float(first_row.get(key, ""))
+            candidate = key
+            break
+        except Exception:
+            continue
+total = 0.0
+if candidate:
+    for r in rows:
+        try:
+            total += float(r.get(candidate, ""))
+        except Exception:
+            continue
+total
+"#;
+
+#[test]
+fn variant_ac_3rows_via_run() {
+    let result = run_via_run(VARIANT_AC).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_ac_3rows_via_start_resume() {
+    let result = run_via_start_resume(VARIANT_AC).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+// ---------------------------------------------------------------------------
+// Variant W: bare 3 loops with dict, try in 2nd+3rd (passes in dart_monty)
+// ---------------------------------------------------------------------------
+
+const VARIANT_W: &str = r#"
+d = {"a": 1, "b": 2, "c": 3}
+x = None
+for k in d:
+    x = k
+    break
+if x is None:
+    for k in d:
+        try:
+            x = k
+            break
+        except Exception:
+            continue
+total = 0
+for k in d:
+    try:
+        total += d[k]
+    except Exception:
+        continue
+total
+"#;
+
+#[test]
+fn variant_w_bare_dict_via_run() {
+    let result = run_via_run(VARIANT_W).unwrap();
+    assert_eq!(result, MontyObject::Int(6));
+}
+
+#[test]
+fn variant_w_bare_dict_via_start_resume() {
+    let result = run_via_start_resume(VARIANT_W).unwrap();
+    assert_eq!(result, MontyObject::Int(6));
+}
+
+// ---------------------------------------------------------------------------
+// Variant O: full step6 pattern, pure python data, 4 rows (FAILS in dart)
+// ---------------------------------------------------------------------------
+
+const VARIANT_O: &str = r#"
+rows = [
+    {"id": 1, "name": "Alice", "value": 250.0},
+    {"id": 2, "name": "Bob", "value": 175.5},
+    {"id": 3, "name": "Charlie", "value": ""},
+    {"id": 4, "name": "Dana", "value": 324.5},
+]
+first_row = rows[0]
+candidate = None
+for key in first_row:
+    low = key.lower()
+    if "value" in low:
+        candidate = key
+        break
+if candidate is None:
+    for key in first_row:
+        try:
+            _ = float(first_row.get(key, ""))
+            candidate = key
+            break
+        except Exception:
+            continue
+total = 0.0
+if candidate:
+    for r in rows:
+        try:
+            val = r.get(candidate, "")
+            total += float(val)
+        except Exception:
+            continue
+total
+"#;
+
+#[test]
+fn variant_o_full_pattern_via_run() {
+    let result = run_via_run(VARIANT_O).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_o_full_pattern_via_start_resume() {
+    let result = run_via_start_resume(VARIANT_O).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+// ---------------------------------------------------------------------------
+// Variant AB: K-style, pure data, 4 rows (FAILS in dart)
+// ---------------------------------------------------------------------------
+
+const VARIANT_AB: &str = r#"
+rows = [
+    {"id": 1, "name": "Alice", "value": 250.0},
+    {"id": 2, "name": "Bob", "value": 175.5},
+    {"id": 3, "name": "Charlie", "value": ""},
+    {"id": 4, "name": "Dana", "value": 324.5},
+]
+first_row = rows[0]
+candidate = None
+for key in first_row:
+    if key == "value":
+        candidate = key
+        break
+if candidate is None:
+    for key in first_row:
+        try:
+            _ = float(first_row.get(key, ""))
+            candidate = key
+            break
+        except Exception:
+            continue
+total = 0.0
+if candidate:
+    for r in rows:
+        try:
+            total += float(r.get(candidate, ""))
+        except Exception:
+            continue
+total
+"#;
+
+#[test]
+fn variant_ab_4rows_via_run() {
+    let result = run_via_run(VARIANT_AB).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_ab_4rows_via_start_resume() {
+    let result = run_via_start_resume(VARIANT_AB).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+// ---------------------------------------------------------------------------
+// With external functions: mimics dart_monty's print preamble pattern
+// ---------------------------------------------------------------------------
+
+const WITH_EXT_FN: &str = r#"
+rows = [
+    {"id": 1, "name": "Alice", "value": 250.0},
+    {"id": 2, "name": "Bob", "value": 175.5},
+    {"id": 3, "name": "Charlie", "value": ""},
+    {"id": 4, "name": "Dana", "value": 324.5},
+]
+first_row = rows[0]
+candidate = None
+for key in first_row:
+    if key == "value":
+        candidate = key
+        break
+if candidate is None:
+    for key in first_row:
+        try:
+            _ = float(first_row.get(key, ""))
+            candidate = key
+            break
+        except Exception:
+            continue
+total = 0.0
+if candidate:
+    for r in rows:
+        try:
+            total += float(r.get(candidate, ""))
+        except Exception:
+            continue
+capture(total)
+total
+"#;
+
+/// Same variant K but with an external function call at the end.
+/// This adds a FunctionCall yield/resume cycle after the for-loops.
+#[test]
+fn variant_k_with_ext_fn_via_start_resume() {
+    let result = run_via_start_resume_with_ext(WITH_EXT_FN, &["capture"]).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+// ===========================================================================
+// dart_monty-style tests: CancellableTracker + PrintWriter::Collect
+// with short-lived buffers per NameLookup (matching handle.rs exactly)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// WITH PRINT PREAMBLE: the exact code dart_monty prepends before user code
+// ---------------------------------------------------------------------------
+
+/// The exact print preamble dart_monty injects (from default_monty_bridge.dart).
+const PREAMBLE: &str = r#"
+def _cw(*a, sep=' ', end='\n', **k):
+    __console_write__(sep.join(str(x) for x in a) + end)
+print = _cw
+"#;
+
+/// Run with preamble + CancellableTracker + Collect buffers + __console_write__ as ext fn.
+/// This matches what dart_monty's DefaultMontyBridge actually does.
+fn run_with_preamble(code: &str) -> Result<MontyObject, monty::MontyException> {
+    let full_code = format!("{}\n{}", PREAMBLE, code);
+    let runner = MontyRun::new(full_code, "test.py", vec![]).unwrap();
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    let tracker = CancellableTracker::with_flag(NoLimitTracker, cancel_flag);
+    let mut start_buf = String::new();
+    let progress = runner.start(vec![], tracker, PrintWriter::Collect(&mut start_buf))?;
+    drive_to_completion_dartmonty_style(progress, &["__console_write__"])
+}
+
+#[test]
+fn minimal_crash_with_preamble() {
+    let result = run_with_preamble(MINIMAL_CRASH).unwrap();
+    assert_eq!(result, MontyObject::Int(16));
+}
+
+#[test]
+fn variant_k_with_preamble() {
+    let result = run_with_preamble(VARIANT_K).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_o_with_preamble() {
+    let result = run_with_preamble(VARIANT_O).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_ab_with_preamble() {
+    let result = run_with_preamble(VARIANT_AB).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn minimal_crash_dartmonty_style() {
+    let result = run_via_start_resume_dartmonty_style(MINIMAL_CRASH).unwrap();
+    assert_eq!(result, MontyObject::Int(16));
+}
+
+#[test]
+fn variant_k_dartmonty_style() {
+    let result = run_via_start_resume_dartmonty_style(VARIANT_K).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_o_dartmonty_style() {
+    let result = run_via_start_resume_dartmonty_style(VARIANT_O).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}
+
+#[test]
+fn variant_ab_dartmonty_style() {
+    let result = run_via_start_resume_dartmonty_style(VARIANT_AB).unwrap();
+    assert_eq!(result, MontyObject::Float(750.0));
+}


### PR DESCRIPTION
## Summary
Fork patches rebased onto upstream `origin/main` (post-v0.0.8). Clean 5-commit diff.

## Commits
1. `chore(ci)`: Fork CI + upstream sync workflows
2. `fix(vm)`: Fix partial future resolution panics in mixed gathers
3. `feat(vm)`: CancellableTracker for preemptive script cancellation
4. `fix(test)`: Adapt async gather tests for PrintWriter by-value API
5. `test(vm)`: ForIter start/resume reproducer (23 variants) for dart_monty#225

## Changelog

### Added
- `CancellableTracker`: preemptive cancellation via `Arc<AtomicBool>` checked on every `check_time` and `on_allocate`
- Fork CI workflow (`fork-ci.yml`) and upstream sync workflow (`sync.yml`)
- 23-variant ForIter regression test covering nested for-loops + try/except via start/resume

### Fixed
- Partial future resolution panics when resolving mixed async gathers out of order

## Test plan
- [x] `make test-ref-count-panic` — all Rust tests pass
- [x] `make test-py` — 758 Python tests pass
- [x] ForIter reproducer — 23/23 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)